### PR TITLE
Update full-card.ts

### DIFF
--- a/src/cards/full-card.ts
+++ b/src/cards/full-card.ts
@@ -1978,7 +1978,7 @@ export const fullCard = (config: sunsynkPowerFlowCardConfig, inverterImg: string
                                         <text id="energy_cost" x="414" y="305"  class="${!config.show_grid ? 'st12' : 'st3 right-align'}" 
                                               fill="${data.gridColour}" 
                                               display="${config.entities?.energy_cost_sell && data.stateEnergyCostSell.isValid() ? '' : 'none'}" >
-                                            ${data.energyCost}}
+                                            ${data.energyCost}
                                         </text>
                                         <text id="energy_cost" x="414" y="318"  class="${!config.show_grid ? 'st12' : 'st3 right-align'}" 
                                               fill="${data.gridColour}" 


### PR DESCRIPTION
Typo had a surplus } that was causing the energy_cost_sell to appear in the format of '0.07} $/kWh'.

<!--- Provide a general summary of your changes in the Title above. -->

## Description
Fixes: 
![image](https://github.com/slipx06/sunsynk-power-flow-card/assets/108674933/044a4818-4120-4b11-9087-3d17d69be99e)

## Motivation and Context
Typo fix

## How has this been tested
slipx06 please validate, I've got no idea how to compile into a new build.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the version in `package.json` following [semver](https://semver.org/)

