### PR TITLE
change behavior for remaining kwh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sunsynk-power-flow-card",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "A customizable Home Assistant card to emulate the Sunsynk System flow that's displayed on the Inverter screen.",
   "main": "sunsynk-power-flow-card.js",
   "scripts": {

--- a/src/cards/full-card.ts
+++ b/src/cards/full-card.ts
@@ -340,7 +340,7 @@ export const fullCard = (config: sunsynkPowerFlowCardConfig, inverterImg: string
                     <text x="101" y="378" class="st3"
                           display="${!config.show_battery || !config.battery.show_remaining_energy ? 'none' : ''}"
                           fill="${data.batteryColour}">
-                        ${Utils.toNum((data.batteryEnergy * (data.stateBatterySoc?.toNum() / 100) / 1000), 2)}
+                        ${Utils.toNum((data.batteryEnergy * ((data.stateBatterySoc?.toNum()-data.shutdown_soc?.toNum()) / 100) / 1000), 2)}
                         ${UnitOfEnergy.KILO_WATT_HOUR}
                     </text>
                     <text x="411" y="157" class="st3 st8"


### PR DESCRIPTION
I don't know if I have made the math correct, this language is not what I am used to

<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
<!--- If the change is breaking, it must be detailed what breaks and what users need to do to fix it -->
new way to calculate remaining kWh

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What additions does it bring? -->
If my battery has 30000 Wh and my end SoC is at 10%.
Today it shows eg. 3 kWh when SoC is at 10% which can be misleading.

## How has this been tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of the tests you ran. -->
I couldn't test it. I tried to change in -js file in HA but it never worked.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have updated the version in `package.json` following [semver](https://semver.org/)

