### PR TITLE
Fix typo in OnGrid Status

### DIFF
--- a/src/inverters/brands/sigenergy.ts
+++ b/src/inverters/brands/sigenergy.ts
@@ -71,7 +71,7 @@ export class Sigenergy extends InverterSettingsDto {
 		ongrid: {
 			states: ['on grid'],
 			color: 'green',
-			message: localize('common.offgrid'),
+			message: localize('common.ongrid'),
 		},
 		offgrid: {
 			states: ['off grid (auto)', 'off grid (manual)'],


### PR DESCRIPTION
Typo found in the defining of the On Grid status. Accidentally had common.offgrid  instead of common.ongrid.