### PR TITLE
feat: add backup generator support as alternative AC source

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Refer to [https://slipx06.github.io/sunsynk-power-flow-card/index.html](https://
 - Display additional non-essential, essential and AUX loads.
 - Display energy cost per kWh and solar sell status.
 - Select your inverter model for custom inverter status and battery status messages i.e. Sunsynk, Lux, Goodwe, Solis.
+- Backup generator support: automatically replaces the grid display with a generator icon and data when a generator is detected as the active AC source. Supports both on-grid (backup) and off-grid setups.
 
 ## Screenshots
 
@@ -61,6 +62,13 @@ _Wide Lite Version (2 batteries)_
 _Wide Compact Version (2 batteries)_
 
 ![{B8CBC3C3-0E0A-4E37-B489-C41CB8EA4E7E}](https://github.com/user-attachments/assets/1cd5508d-33a0-4df9-9665-5a4d9e753178)
+
+_Backup Generator Mode_
+
+| Card Style  | Grid Mode                                                                                        | Generator Mode                                                                                        |
+| ----------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| **Full**    | ![full-grid](https://github.com/user-attachments/assets/a122a428-55a1-446d-a3b4-036790402af1)    | ![full-generator](https://github.com/user-attachments/assets/b4620424-c0f1-42d3-bead-75b27c671685)    |
+| **Compact** | ![compact-grid](https://github.com/user-attachments/assets/fa2da3c8-51a3-4fe9-bd88-17e4852a8562) | ![compact-generator](https://github.com/user-attachments/assets/6be5a6bd-60f7-416a-9d98-a608d9442e96) |
 
 ## Installation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -239,6 +239,56 @@ These attributes are only needed if `show_solar` is set to `true`.
 | navigate:              | Optional    |                 | Sets the navigation path when clicking on the grid image. Can be used to link to other dashboards and views e.g. `/lovelace/1.                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | invert_flow:           | Optional    | `false`         | Inverts the animated flow.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 
+### Generator
+
+The generator section allows the card to display a backup generator as an alternative AC input source. When the generator is active (detected via a status sensor), the grid icon is replaced with a generator icon and all grid values are replaced with generator values. Non-essential loads are hidden as generator and grid are mutually exclusive AC sources.
+
+This works for both **on-grid with backup generator** (e.g. grid outage triggers generator) and **off-grid with generator only** setups.
+
+| Attribute      | Requirement | Default              | Description                                                                                                                                                                                                                                                                                                                                   |
+| -------------- | ----------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| colour:        | Optional    | `'#FFCD11'`          | Sets the colour of all generator card objects when active. Hex codes (`'#66ff00'` etc) or names (`red`, `green`, `blue` etc).                                                                                                                                                                                                                 |
+| name:          | Optional    |                      | Set the display name for the generator (shown below the icon).                                                                                                                                                                                                                                                                                |
+| show_daily:    | Optional    | `false`              | Toggles the daily generator energy total. Requires `day_generator_energy` entity to be set.                                                                                                                                                                                                                                                   |
+| navigate:      | Optional    |                      | Sets the navigation path when clicking on the generator image.                                                                                                                                                                                                                                                                                |
+| active_states: | Optional    | `['generator', '1']` | List of state values (case insensitive) that indicate the generator is active. Works with any entity type — binary sensor (`on`/`off`), text sensor (e.g. `Generator`/`Grid`), or numeric register (e.g. `1`/`0`). No helper entity needed. The card switches to generator mode when `generator_status` state matches any value in this list. |
+| max_power:     | Optional    | `8000`               | Maximum generator power (W) used to calculate the flow animation speed.                                                                                                                                                                                                                                                                       |
+
+**Example configuration:**
+
+```yaml
+generator:
+  colour: '#FFCD11'
+  name: Generator
+  show_daily: true
+  active_states:
+    - Generator
+  max_power: 8000
+```
+
+The `active_states` list works with any entity type — no helper entity required:
+
+```yaml
+# Binary sensor (e.g. binary_sensor.generator_running)
+active_states:
+  - "on"
+
+# Text sensor (e.g. sensor.ac_input_type reporting "Generator" or "Grid")
+active_states:
+  - Generator
+
+# Numeric register (e.g. sensor reporting 1 when generator active)
+active_states:
+  - "1"
+```
+
+_Generator mode (active)_
+
+| Grid Mode                                                                                        | Generator Mode                                                                                        |
+| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| ![full-grid](https://github.com/user-attachments/assets/a122a428-55a1-446d-a3b4-036790402af1)    | ![full-generator](https://github.com/user-attachments/assets/b4620424-c0f1-42d3-bead-75b27c671685)    |
+| ![compact-grid](https://github.com/user-attachments/assets/fa2da3c8-51a3-4fe9-bd88-17e4852a8562) | ![compact-generator](https://github.com/user-attachments/assets/6be5a6bd-60f7-416a-9d98-a608d9442e96) |
+
 ### Entities
 
 The entity attributes below have been appended with the Modbus register # e.g. `pv2_power_187` to indicate which Sunsynk
@@ -399,6 +449,17 @@ mappings if using other integration methods.
 | energy_cost_sell:          | Optional     |                                               | Sensor that provides current sell energy cost per kWh.                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | prepaid_units:             | Optional     |                                               | Account balance of prepaid electricity units.                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | max_sell_power:            | Optional     | `number.sunsynk_max_sell_power`               | Sets the maximum allowed output power to flow to the grid. Also known as "Export Control User Limit" (W).                                                                                                                                                                                                                                                                                                                                                                                 |
+
+#### Generator Entities
+
+| Attribute             | Requirement | Default | Description                                                                                                                                                   |
+| --------------------- | ----------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| generator_status:     | Optional    |         | Sensor whose state is compared against `generator.active_states` to determine if the generator is running. When matched, the card switches to generator mode. |
+| generator_power:      | Optional    |         | Generator output power (W). Displayed in place of grid power when generator is active.                                                                        |
+| generator_voltage:    | Optional    |         | Generator output voltage (V). Displayed in place of inverter voltage when generator is active.                                                                |
+| generator_frequency:  | Optional    |         | Generator output frequency (Hz). Displayed in place of load frequency when generator is active.                                                               |
+| generator_current:    | Optional    |         | Generator output current (A).                                                                                                                                 |
+| day_generator_energy: | Optional    |         | Daily generator energy production (kWh). Displayed when `generator.show_daily: true`.                                                                         |
 
 The card calculates the sensors below based on supplied attributes in the config, so you don't need to define them in Home
 Assistant. NOTE if your essential and non-essential readings are inaccurate, replace sensor 169 with 167. Alternatively,

--- a/docs/examples/lux.rst
+++ b/docs/examples/lux.rst
@@ -132,3 +132,118 @@ Example 2 using the lxp-bridge integration (https://github.com/celsworth/lxp-bri
 .. note::
 
    Replace ``baXXXXXXXX`` with your wifi dongle number
+
+*************************************************************************************
+Example 3 using the ant0nkr/luxpower-ha-integration with backup generator support
+*************************************************************************************
+
+.. code-block:: yaml
+  :linenos:
+
+  cardstyle: lite
+  path_threshold: 100
+  large_font: true
+  show_battery: true
+  show_grid: true
+  decimal_places: 2
+  inverter:
+    model: lux
+    modern: false
+  battery:
+    energy: 30000
+    shutdown_soc: number.lxp_off_grid_cut_off_soc
+    shutdown_soc_offgrid: number.lxp_on_grid_cut_off_soc
+    show_daily: true
+    invert_power: false
+    show_absolute: false
+    animate: false
+    max_power: 12000
+  solar:
+    show_daily: true
+    mppts: 2
+    pv1_name: PV1
+    pv1_max_power: 4920
+    pv2_name: PV2
+    pv2_max_power: 4920
+    auto_scale: true
+    max_power: 9000
+    efficiency: 2
+    display_mode: 3
+  load:
+    show_daily: true
+    additional_loads: 4
+    dynamic_icon: true
+    load1_name: Load 1
+    load2_name: Load 2
+    load3_name: Load 3
+    load4_name: Load 4
+    max_power: 38000
+    essential_name: Essential
+  grid:
+    show_daily_buy: true
+    show_daily_sell: true
+    show_nonessential: false
+    invert_grid: false
+    additional_loads: 2
+    grid_name: Grid
+    energy_cost_decimals: 2
+    max_power: 38000
+    grid_off_colour: "#ff0000"
+    no_grid_colour: "#a40013"
+  generator:
+    colour: "#FFCD11"
+    name: Generator
+    show_daily: true
+    active_states:
+      - Generator
+    max_power: 11000
+  type: custom:sunsynk-power-flow-card
+  entities:
+    inverter_voltage_154: sensor.lxp_eps_voltage
+    load_frequency_192: sensor.lxp_eps_frequency
+    inverter_current_164: sensor.lxp_inverter_current
+    inverter_status_59: sensor.lxp_inverter_state_code
+    inverter_power_175: sensor.lxp_battery_flow
+    day_battery_charge_70: sensor.lxp_charge_energy_today
+    day_battery_discharge_71: sensor.lxp_discharge_energy_today
+    battery_voltage_183: sensor.lxp_battery_voltage
+    battery_soc_184: sensor.lxp_battery_soc
+    battery_power_190: sensor.lxp_battery_flow
+    battery_current_191: sensor.lxp_bms_battery_current
+    grid_power_169: sensor.lxp_grid_flow
+    day_grid_import_76: sensor.lxp_energy_from_grid_today
+    day_grid_export_77: sensor.lxp_energy_to_grid_today
+    grid_ct_power_172: sensor.lxp_grid_flow
+    grid_connected_status_194: binary_sensor.lxp_grid_connected
+    day_load_energy_84: sensor.lxp_load_consumption_today
+    essential_power: sensor.lxp_load_power
+    nonessential_power: none
+    day_pv_energy_108: sensor.lxp_pv_energy_today
+    pv_total: sensor.lxp_pv_power
+    total_pv_generation: sensor.lxp_pv_energy_total
+    pv1_power_186: sensor.lxp_pv1_power
+    pv2_power_187: sensor.lxp_pv2_power
+    pv1_voltage_109: sensor.lxp_pv1_voltage
+    pv1_current_110: sensor.lxp_pv1_current
+    pv2_voltage_111: sensor.lxp_pv2_voltage
+    pv2_current_112: sensor.lxp_pv2_current
+    radiator_temp_91: sensor.lxp_radiator_temperature
+    dc_transformer_temp_90: sensor.lxp_radiator_temperature_2
+    battery_temp_182: sensor.lxp_bms_min_cell_temperature
+    remaining_solar: sensor.energy_production_today_remaining
+    essential_load1: sensor.load1_power
+    essential_load2: sensor.load2_power
+    essential_load3: sensor.load3_power
+    essential_load4: sensor.load4_power
+    generator_status: sensor.lxp_ac_input_type
+    generator_power: sensor.lxp_generator_power
+    generator_voltage: sensor.lxp_generator_voltage
+    generator_frequency: sensor.lxp_generator_frequency
+    day_generator_energy: sensor.lxp_generator_energy_today
+
+.. note::
+
+   This example uses the `ant0nkr/luxpower-ha-integration <https://github.com/ant0nkr/luxpower-ha-integration>`_.
+   The generator section replaces the grid display when ``sensor.lxp_ac_input_type`` reports ``Generator``.
+   PV strings are mapped to physical MPPT ports (pv1 → MPPT3, pv2 → MPPT2) to match the actual installation.
+   The ``binary_sensor.lxp_grid_connected`` entity is a calculated sensor derived from the inverter state register.

--- a/src/components/compact/grid/grid-elements.ts
+++ b/src/components/compact/grid/grid-elements.ts
@@ -23,6 +23,15 @@ const renderGridIcons = (data: DataDto, config: sunsynkPowerFlowCardConfig) => {
 	const showGrid = config.show_grid;
 	const totalGridPower = data.totalGridPower;
 	const gridColour = data.gridColour;
+	const { generatorActive, generatorColour } = data;
+
+	if (generatorActive) {
+		return svg`
+            <svg id="generator_icon" x="-0.5" y="187.5" width="64.5" height="64.5" viewBox="0 0 24 24">
+                <path fill="${generatorColour}" d="${icons.generator}"/>
+            </svg>
+        `;
+	}
 
 	return svg`
         <svg id="transmission_on" x="-0.5" y="187.5" width="64.5" height="64.5" viewBox="0 0 24 24">
@@ -54,11 +63,17 @@ const renderGridTotalPower = (
 	const show_absolute = config.grid.show_absolute;
 	const decimalPlaces = data.decimalPlaces;
 	const largeFont = data.largeFont;
-	const gridColour = data.gridColour;
+	const { generatorActive, generatorColour, stateGeneratorPower } = data;
+	const gridColour = generatorActive ? generatorColour : data.gridColour;
 
 	let powerValue: string | number;
 
-	if (auto_scale) {
+	if (generatorActive) {
+		const genPower = stateGeneratorPower.toPower();
+		powerValue = auto_scale
+			? Utils.convertValue(genPower, decimalPlaces) || '0'
+			: genPower || 0;
+	} else if (auto_scale) {
 		const convertedValue = Utils.convertValue(totalGridPower, decimalPlaces);
 		powerValue = show_absolute
 			? Utils.convertValue(Math.abs(totalGridPower), decimalPlaces) || '0'
@@ -69,7 +84,7 @@ const renderGridTotalPower = (
 
 	return svg`
         <text id="grid_total_power" x="135" y="219.2"
-            display="${!config.show_grid || config.entities.grid_ct_power_172 === 'none' ? 'none' : ''}"
+            display="${!config.show_grid || (!generatorActive && config.entities.grid_ct_power_172 === 'none') ? 'none' : ''}"
             class="${largeFont !== true ? 'st14' : 'st4'} st8" fill="${gridColour}">
             ${powerValue} ${!auto_scale ? UnitOfPower.WATT : ''}
         </text>
@@ -80,21 +95,36 @@ export const renderGridElements = (
 	data: DataDto,
 	config: sunsynkPowerFlowCardConfig,
 ) => {
-	const { decimalPlaces, gridColour, totalGridPower } = data;
+	const {
+		decimalPlaces,
+		totalGridPower,
+		generatorActive,
+		generatorColour,
+		stateGeneratorPower,
+		stateDayGeneratorEnergy,
+		stateGeneratorVoltage,
+		stateGeneratorFrequency,
+	} = data;
+
+	const gridColour = generatorActive ? generatorColour : data.gridColour;
 
 	const { auto_scale, invert_flow } = config.grid;
 
 	const { three_phase } = config.inverter;
 
+	const acFlowPower = generatorActive
+		? stateGeneratorPower.toPower() || 0
+		: totalGridPower;
+
 	const gridFlowKeyPoints = invert_flow
-		? Utils.invertKeyPoints(totalGridPower < 0 ? '1;0' : '0;1')
-		: totalGridPower < 0
+		? Utils.invertKeyPoints(acFlowPower < 0 ? '1;0' : '0;1')
+		: acFlowPower < 0
 			? '1;0'
 			: '0;1';
 
 	const grid1FlowKeyPoints = invert_flow
-		? Utils.invertKeyPoints(totalGridPower < 0 ? '0;1' : '1;0')
-		: totalGridPower < 0
+		? Utils.invertKeyPoints(acFlowPower < 0 ? '0;1' : '1;0')
+		: acFlowPower < 0
 			? '0;1'
 			: '1;0';
 
@@ -124,15 +154,24 @@ export const renderGridElements = (
 				282.1,
 				!config.show_grid,
 				'st3 left-align',
-				data.gridShowDailyBuy !== true ? 'transparent' : gridColour,
-				config.grid.label_daily_grid_buy || localize('common.daily_grid_buy'),
+				generatorActive
+					? config.generator?.show_daily && stateDayGeneratorEnergy.isValid()
+						? gridColour
+						: 'transparent'
+					: data.gridShowDailyBuy !== true
+						? 'transparent'
+						: gridColour,
+				generatorActive
+					? localize('common.daily_generator_energy')
+					: config.grid.label_daily_grid_buy ||
+							localize('common.daily_grid_buy'),
 				true,
 			)}
 			${renderText(
 				'daily_grid_sell',
 				5,
 				179,
-				!config.show_grid,
+				!config.show_grid || generatorActive,
 				'st3 left-align',
 				data.gridShowDailySell !== true ? 'transparent' : gridColour,
 				config.grid.label_daily_grid_sell || localize('common.daily_grid_sell'),
@@ -145,7 +184,9 @@ export const renderGridElements = (
 				!config.show_grid,
 				'st3 st8 left-align',
 				gridColour,
-				config.grid.grid_name || localize('common.grid_name'),
+				generatorActive
+					? config.generator?.name || localize('common.generator_name')
+					: config.grid.grid_name || localize('common.grid_name'),
 				true,
 			)}
 			<svg id="grid-flow">
@@ -162,7 +203,7 @@ export const renderGridElements = (
 						2 + data.gridLineWidth + Math.max(data.minLineWidth - 2, 0),
 						8,
 					),
-					totalGridPower === 0 ? 'transparent' : gridColour,
+					acFlowPower === 0 ? 'transparent' : gridColour,
 					data.durationCur['grid'],
 					gridFlowKeyPoints,
 					'#grid-line',
@@ -182,7 +223,7 @@ export const renderGridElements = (
 						2 + data.gridLineWidth + Math.max(data.minLineWidth - 2, 0),
 						8,
 					),
-					totalGridPower === 0 ? 'transparent' : gridColour,
+					acFlowPower === 0 ? 'transparent' : gridColour,
 					data.durationCur['grid'],
 					grid1FlowKeyPoints,
 					'#grid-line1',
@@ -194,7 +235,7 @@ export const renderGridElements = (
                         ${renderGridIcons(data, config)}
                     </a>`
 				: svg`
-                    <a href="#" @click=${(e) => Utils.handlePopup(e, config.entities.grid_connected_status_194)}>
+                    <a href="#" @click=${(e) => Utils.handlePopup(e, generatorActive ? config.entities.generator_status : config.entities.grid_connected_status_194)}>
                         ${renderGridIcons(data, config)}
                     </a>`}
 			${config.grid?.navigate
@@ -223,12 +264,31 @@ export const renderGridElements = (
 				5,
 				267.9,
 				!config.show_grid ||
-					data.gridShowDailyBuy !== true ||
-					!data.stateDayGridImport.isValid(),
+					(generatorActive
+						? !(
+								config.generator?.show_daily &&
+								stateDayGeneratorEnergy.isValid()
+							)
+						: data.gridShowDailyBuy !== true ||
+							!data.stateDayGridImport.isValid()),
 				'st10 left-align',
 				gridColour,
-				data.stateDayGridImport?.toPowerString(true, data.decimalPlacesEnergy),
-				(e) => Utils.handlePopup(e, config.entities.day_grid_import_76),
+				generatorActive
+					? stateDayGeneratorEnergy?.toPowerString(
+							true,
+							data.decimalPlacesEnergy,
+						)
+					: data.stateDayGridImport?.toPowerString(
+							true,
+							data.decimalPlacesEnergy,
+						),
+				(e) =>
+					Utils.handlePopup(
+						e,
+						generatorActive
+							? config.entities.day_generator_energy
+							: config.entities.day_grid_import_76,
+					),
 				true,
 			)}
 			${createTextWithPopup(
@@ -236,12 +296,27 @@ export const renderGridElements = (
 				5,
 				165,
 				!config.show_grid ||
+					generatorActive ||
 					data.gridShowDailySell !== true ||
 					!data.stateDayGridExport.isValid(),
 				'st10 left-align',
 				gridColour,
 				data.stateDayGridExport?.toPowerString(true, data.decimalPlacesEnergy),
 				(e) => Utils.handlePopup(e, config.entities.day_grid_export_77),
+				true,
+			)}
+			${createTextWithPopup(
+				'generator_ac_compact',
+				5,
+				173,
+				!config.show_grid ||
+					!generatorActive ||
+					!config.entities?.generator_voltage ||
+					!stateGeneratorVoltage?.isValid(),
+				'st10 left-align',
+				generatorColour,
+				`${stateGeneratorVoltage?.toNum(1)} V / ${stateGeneratorFrequency?.toNum(2)} Hz`,
+				(e) => Utils.handlePopup(e, config.entities.generator_voltage),
 				true,
 			)}
 			${createTextWithPopup(
@@ -266,7 +341,7 @@ export const renderGridElements = (
 					: svg`
                             ${renderGridTotalPower(data, config)}`
 				: svg`
-                    <a href="#" @click=${(e) => Utils.handlePopup(e, config.entities.grid_ct_power_172)}>
+                    <a href="#" @click=${(e) => Utils.handlePopup(e, generatorActive ? config.entities.generator_power : config.entities.grid_ct_power_172)}>
                         ${renderGridTotalPower(data, config)}
                     </a>`}
 			${totalGridPower >= 0

--- a/src/components/full/grid/grid-elements.ts
+++ b/src/components/full/grid/grid-elements.ts
@@ -29,6 +29,19 @@ const renderGridIcons = (data: DataDto, config: sunsynkPowerFlowCardConfig) => {
 	const totalGridPower = data.totalGridPower;
 	const gridColour = data.gridColour;
 	const three_phase = config.inverter.three_phase;
+	const { generatorActive, generatorColour } = data;
+
+	if (generatorActive) {
+		return svg`
+            <svg xmlns="http://www.w3.org/2000/svg" id="generator_icon"
+                x="${three_phase ? '404' : '389'}"
+                y="${three_phase ? '339' : '308'}"
+                width="${three_phase ? '34' : '65'}"
+                height="${three_phase ? '34' : '65'}" viewBox="0 0 24 24">
+                <path fill="${generatorColour}" d="${icons.generator}"/>
+            </svg>
+        `;
+	}
 
 	return svg`
         <svg xmlns="http://www.w3.org/2000/svg" id="transmission_on"
@@ -69,13 +82,25 @@ export const renderGridElements = (
 ) => {
 	const {
 		nonessentialLoads,
-		showNonessential,
 		decimalPlaces,
-		gridColour,
 		largeFont,
 		totalGridPower,
 		autoScaledGridPower,
+		generatorActive,
+		generatorColour,
+		stateGeneratorPower,
+		stateGeneratorVoltage,
+		stateGeneratorFrequency,
+		stateDayGeneratorEnergy,
 	} = data;
+
+	// When generator is active, use its colour and suppress nonessential loads
+	const activeColour = generatorActive ? generatorColour : data.gridColour;
+	const gridColour = activeColour;
+	const showNonessential = generatorActive ? false : data.showNonessential;
+	const acFlowPower = generatorActive
+		? stateGeneratorPower.toPower() || 0
+		: totalGridPower;
 
 	const { auto_scale, invert_flow } = config.grid;
 
@@ -282,7 +307,9 @@ export const renderGridElements = (
 				true,
 				'st3 st8',
 				gridColour,
-				config.grid.grid_name || localize('common.grid_name'),
+				generatorActive
+					? config.generator?.name || localize('common.generator_name')
+					: config.grid.grid_name || localize('common.grid_name'),
 			)}
 			${renderText(
 				'daily_grid_buy',
@@ -292,10 +319,15 @@ export const renderGridElements = (
 					: config.entities?.max_sell_power
 						? '256'
 						: '253',
-				data.gridShowDailyBuy !== true,
+				generatorActive
+					? !(config.generator?.show_daily && stateDayGeneratorEnergy.isValid())
+					: data.gridShowDailyBuy !== true,
 				'st3 left-align',
 				gridColour,
-				config.grid.label_daily_grid_buy || localize('common.daily_grid_buy'),
+				generatorActive
+					? localize('common.daily_generator_energy')
+					: config.grid.label_daily_grid_buy ||
+							localize('common.daily_grid_buy'),
 				true,
 			)}
 			${renderText(
@@ -306,7 +338,7 @@ export const renderGridElements = (
 					: config.entities?.max_sell_power
 						? '225'
 						: '222',
-				data.gridShowDailySell !== true,
+				generatorActive || data.gridShowDailySell !== true,
 				'st3 left-align',
 				gridColour,
 				config.grid.label_daily_grid_sell || localize('common.daily_grid_sell'),
@@ -336,7 +368,7 @@ export const renderGridElements = (
 						2 + data.gridLineWidth + Math.max(data.minLineWidth - 2, 0),
 						8,
 					),
-					totalGridPower <= 0 ? 'transparent' : gridColour,
+					acFlowPower <= 0 ? 'transparent' : gridColour,
 					data.durationCur['grid'],
 					'1;0',
 					'#grid-line',
@@ -348,7 +380,7 @@ export const renderGridElements = (
 						2 + data.gridLineWidth + Math.max(data.minLineWidth - 2, 0),
 						8,
 					),
-					totalGridPower >= 0 ? 'transparent' : gridColour,
+					acFlowPower >= 0 ? 'transparent' : gridColour,
 					data.durationCur['grid'],
 					'0;1',
 					'#grid-line',
@@ -369,7 +401,7 @@ export const renderGridElements = (
 						2 + data.gridLineWidth + Math.max(data.minLineWidth - 2, 0),
 						8,
 					),
-					totalGridPower <= 0 ? 'transparent' : gridColour,
+					acFlowPower <= 0 ? 'transparent' : gridColour,
 					data.durationCur['grid'] / 1.5,
 					'1;0',
 					'#grid-line1',
@@ -381,7 +413,7 @@ export const renderGridElements = (
 						2 + data.gridLineWidth + Math.max(data.minLineWidth - 2, 0),
 						8,
 					),
-					totalGridPower >= 0 ? 'transparent' : gridColour,
+					acFlowPower >= 0 ? 'transparent' : gridColour,
 					data.durationCur['grid'] / 1.5,
 					'0;1',
 					'#grid-line1',
@@ -448,9 +480,7 @@ export const renderGridElements = (
 						2 + data.gridLineWidth + Math.max(data.minLineWidth - 2, 0),
 						8,
 					),
-					autoScaledGridPower < 0 || autoScaledGridPower === 0
-						? 'transparent'
-						: gridColour,
+					acFlowPower < 0 || acFlowPower === 0 ? 'transparent' : gridColour,
 					data.durationCur['grid'],
 					'1;0',
 					'#grid2-line',
@@ -462,9 +492,7 @@ export const renderGridElements = (
 						2 + data.gridLineWidth + Math.max(data.minLineWidth - 2, 0),
 						8,
 					),
-					autoScaledGridPower > 0 || autoScaledGridPower === 0
-						? 'transparent'
-						: gridColour,
+					acFlowPower > 0 || acFlowPower === 0 ? 'transparent' : gridColour,
 					data.durationCur['grid'],
 					'0;1',
 					'#grid2-line',
@@ -474,33 +502,37 @@ export const renderGridElements = (
 			${config.grid?.navigate
 				? svg`
                     <a href="#" @click=${(e) => Utils.handleNavigation(e, config.grid.navigate)}>
-							${guard(
-								[
-									data.gridStatus,
-									data.totalGridPower >= 0,
-									data.gridColour,
-									three_phase,
-									config.grid.import_icon,
-									config.grid.export_icon,
-									config.grid.disconnected_icon,
-								],
-								() => renderGridIcons(data, config),
-							)}
+						${guard(
+							[
+								data.gridStatus,
+								data.totalGridPower >= 0,
+								data.gridColour,
+								three_phase,
+								config.grid.import_icon,
+								config.grid.export_icon,
+								config.grid.disconnected_icon,
+								generatorActive,
+								generatorColour,
+							],
+							() => renderGridIcons(data, config),
+						)}
                     </a>`
 				: svg`
-                    <a href="#" @click=${(e) => Utils.handlePopup(e, config.entities.grid_connected_status_194)}>
-							${guard(
-								[
-									data.gridStatus,
-									data.totalGridPower >= 0,
-									data.gridColour,
-									three_phase,
-									config.grid.import_icon,
-									config.grid.export_icon,
-									config.grid.disconnected_icon,
-								],
-								() => renderGridIcons(data, config),
-							)}
+                    <a href="#" @click=${(e) => Utils.handlePopup(e, generatorActive ? config.entities.generator_status : config.entities.grid_connected_status_194)}>
+						${guard(
+							[
+								data.gridStatus,
+								data.totalGridPower >= 0,
+								data.gridColour,
+								three_phase,
+								config.grid.import_icon,
+								config.grid.export_icon,
+								config.grid.disconnected_icon,
+								generatorActive,
+								generatorColour,
+							],
+							() => renderGridIcons(data, config),
+						)}
                     </a>`}
 			${config.grid?.navigate
 				? svg`
@@ -616,11 +648,28 @@ export const renderGridElements = (
 					: config.entities?.max_sell_power
 						? '242'
 						: '239',
-				data.gridShowDailyBuy !== true || !data.stateDayGridImport.isValid(),
+				generatorActive
+					? !(config.generator?.show_daily && stateDayGeneratorEnergy.isValid())
+					: data.gridShowDailyBuy !== true ||
+							!data.stateDayGridImport.isValid(),
 				'st10 left-align',
 				gridColour,
-				data.stateDayGridImport.toPowerString(true, data.decimalPlacesEnergy),
-				(e) => Utils.handlePopup(e, config.entities.day_grid_import_76),
+				generatorActive
+					? stateDayGeneratorEnergy.toPowerString(
+							true,
+							data.decimalPlacesEnergy,
+						)
+					: data.stateDayGridImport.toPowerString(
+							true,
+							data.decimalPlacesEnergy,
+						),
+				(e) =>
+					Utils.handlePopup(
+						e,
+						generatorActive
+							? config.entities.day_generator_energy
+							: config.entities.day_grid_import_76,
+					),
 				true,
 			)}
 			${createTextWithPopup(
@@ -631,7 +680,9 @@ export const renderGridElements = (
 					: config.entities?.max_sell_power
 						? '212'
 						: '209',
-				data.gridShowDailySell !== true || !data.stateDayGridExport.isValid(),
+				generatorActive ||
+					data.gridShowDailySell !== true ||
+					!data.stateDayGridExport.isValid(),
 				'st10 left-align',
 				gridColour,
 				data.stateDayGridExport.toPowerString(true, data.decimalPlacesEnergy),
@@ -663,18 +714,18 @@ export const renderGridElements = (
 														? `${
 																config.grid.show_absolute
 																	? Utils.convertValue(
-																			Math.abs(totalGridPower),
+																			Math.abs(acFlowPower),
 																			decimalPlaces,
 																		) || '0'
 																	: Utils.convertValue(
-																			totalGridPower,
+																			acFlowPower,
 																			decimalPlaces,
 																		) || 0
 															}`
 														: `${
 																config.grid.show_absolute
-																	? `${Math.abs(totalGridPower)} ${UnitOfPower.WATT}`
-																	: `${totalGridPower || 0} ${UnitOfPower.WATT}`
+																	? `${Math.abs(acFlowPower)} ${UnitOfPower.WATT}`
+																	: `${acFlowPower || 0} ${UnitOfPower.WATT}`
 															}`,
 													(e) =>
 														Utils.handlePopup(
@@ -695,18 +746,18 @@ export const renderGridElements = (
 														? `${
 																config.grid.show_absolute
 																	? Utils.convertValue(
-																			Math.abs(totalGridPower),
+																			Math.abs(acFlowPower),
 																			decimalPlaces,
 																		) || '0'
 																	: Utils.convertValue(
-																			totalGridPower,
+																			acFlowPower,
 																			decimalPlaces,
 																		) || 0
 															}`
 														: `${
 																config.grid.show_absolute
-																	? `${Math.abs(totalGridPower)} ${UnitOfPower.WATT}`
-																	: `${totalGridPower || 0} ${UnitOfPower.WATT}`
+																	? `${Math.abs(acFlowPower)} ${UnitOfPower.WATT}`
+																	: `${acFlowPower || 0} ${UnitOfPower.WATT}`
 															}`,
 													true,
 												)}`
@@ -722,21 +773,26 @@ export const renderGridElements = (
 												? `${
 														config.grid.show_absolute
 															? Utils.convertValue(
-																	Math.abs(totalGridPower),
+																	Math.abs(acFlowPower),
 																	decimalPlaces,
 																) || '0'
 															: Utils.convertValue(
-																	totalGridPower,
+																	acFlowPower,
 																	decimalPlaces,
 																) || 0
 													}`
 												: `${
 														config.grid.show_absolute
-															? `${Math.abs(totalGridPower)} ${UnitOfPower.WATT}`
-															: `${totalGridPower || 0} ${UnitOfPower.WATT}`
+															? `${Math.abs(acFlowPower)} ${UnitOfPower.WATT}`
+															: `${acFlowPower || 0} ${UnitOfPower.WATT}`
 													}`,
 											(e) =>
-												Utils.handlePopup(e, config.entities.grid_ct_power_172),
+												Utils.handlePopup(
+													e,
+													generatorActive
+														? config.entities.generator_power
+														: config.entities.grid_ct_power_172,
+												),
 											true,
 										)}`}
 			${config.entities?.nonessential_power &&
@@ -861,24 +917,37 @@ export const renderGridElements = (
 				'grid_power_169',
 				270,
 				three_phase ? 216 : 209,
-				config.entities.grid_power_169 === 'none',
+				!generatorActive && config.entities.grid_power_169 === 'none',
 				`${largeFont !== true ? 'st14' : 'st4'} st8`,
 				gridColour,
-				auto_scale
-					? `${
-							config.grid.show_absolute
-								? Utils.convertValue(
-										Math.abs(autoScaledGridPower),
-										decimalPlaces,
-									) || '0'
-								: Utils.convertValue(autoScaledGridPower, decimalPlaces) || 0
-						}`
-					: `${
-							config.grid.show_absolute
-								? `${Math.abs(autoScaledGridPower)} ${UnitOfPower.WATT}`
-								: `${autoScaledGridPower || 0} ${UnitOfPower.WATT}`
-						}`,
-				(e) => Utils.handlePopup(e, config.entities.grid_power_169),
+				generatorActive
+					? auto_scale
+						? Utils.convertValue(
+								stateGeneratorPower.toPower(),
+								decimalPlaces,
+							) || '0'
+						: `${stateGeneratorPower.toPower() || 0} ${UnitOfPower.WATT}`
+					: auto_scale
+						? `${
+								config.grid.show_absolute
+									? Utils.convertValue(
+											Math.abs(autoScaledGridPower),
+											decimalPlaces,
+										) || '0'
+									: Utils.convertValue(autoScaledGridPower, decimalPlaces) || 0
+							}`
+						: `${
+								config.grid.show_absolute
+									? `${Math.abs(autoScaledGridPower)} ${UnitOfPower.WATT}`
+									: `${autoScaledGridPower || 0} ${UnitOfPower.WATT}`
+							}`,
+				(e) =>
+					Utils.handlePopup(
+						e,
+						generatorActive
+							? config.entities.generator_power
+							: config.entities.grid_power_169,
+					),
 				true,
 			)}
 			${createTextWithPopup(
@@ -932,15 +1001,21 @@ export const renderGridElements = (
 				'inverter_voltage_154',
 				270,
 				three_phase ? 164 : 170.4,
-				config.entities.inverter_voltage_154 === 'none' ||
-					!config.entities.inverter_voltage_154,
+				!generatorActive &&
+					(config.entities.inverter_voltage_154 === 'none' ||
+						!config.entities.inverter_voltage_154),
 				`${largeFont !== true ? 'st14' : 'st4'} st8`,
 				gridColour,
-				`${Utils.formatNumberLocale(
-					data.inverterVoltage,
-					1,
-				)} ${UnitOfElectricPotential.VOLT}`,
-				(e) => Utils.handlePopup(e, config.entities.inverter_voltage_154),
+				generatorActive
+					? `${Utils.formatNumberLocale(stateGeneratorVoltage.toNum(1), 1)} ${UnitOfElectricPotential.VOLT}`
+					: `${Utils.formatNumberLocale(data.inverterVoltage, 1)} ${UnitOfElectricPotential.VOLT}`,
+				(e) =>
+					Utils.handlePopup(
+						e,
+						generatorActive
+							? config.entities.generator_voltage
+							: config.entities.inverter_voltage_154,
+					),
 				true,
 			)}
 			${createTextWithPopup(
@@ -973,12 +1048,21 @@ export const renderGridElements = (
 				'load_frequency_192',
 				270,
 				three_phase ? '203' : '189.5',
-				config.entities.load_frequency_192 === 'none' ||
-					!config.entities.load_frequency_192,
+				!generatorActive &&
+					(config.entities.load_frequency_192 === 'none' ||
+						!config.entities.load_frequency_192),
 				`${largeFont !== true ? 'st14' : 'st4'} st8`,
 				gridColour,
-				`${Utils.formatNumberLocale(data.loadFrequency, 2)} Hz`,
-				(e) => Utils.handlePopup(e, config.entities.load_frequency_192),
+				generatorActive
+					? `${Utils.formatNumberLocale(stateGeneratorFrequency.toNum(2), 2)} Hz`
+					: `${Utils.formatNumberLocale(data.loadFrequency, 2)} Hz`,
+				(e) =>
+					Utils.handlePopup(
+						e,
+						generatorActive
+							? config.entities.generator_frequency
+							: config.entities.load_frequency_192,
+					),
 				true,
 			)}
 			${createTextWithPopup(

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -125,6 +125,14 @@ export default {
 		invert_flow: false,
 		label_daily_load: '',
 	},
+	generator: {
+		colour: '#FFCD11',
+		name: '',
+		show_daily: false,
+		navigate: '',
+		active_states: ['generator', '1'],
+		max_power: 8000,
+	},
 	grid: {
 		colour: '#5490c2',
 		grid_name: '',

--- a/src/index.ts
+++ b/src/index.ts
@@ -605,6 +605,19 @@ export class SunsynkPowerFlowCard extends LitElement {
 			'entities.grid_connected_status_194',
 			{ state: 'on' },
 		);
+		// Generator
+		const stateGeneratorStatus = this.getEntity('entities.generator_status', {
+			state: 'off',
+		});
+		const stateGeneratorPower = this.getEntity('entities.generator_power');
+		const stateGeneratorVoltage = this.getEntity('entities.generator_voltage');
+		const stateGeneratorFrequency = this.getEntity(
+			'entities.generator_frequency',
+		);
+		const stateGeneratorCurrent = this.getEntity('entities.generator_current');
+		const stateDayGeneratorEnergy = this.getEntity(
+			'entities.day_generator_energy',
+		);
 		const stateGridPower = this.getEntity('entities.grid_power_169');
 		const stateEnergyCostBuy = this.getEntity('entities.energy_cost_buy', {
 			state: '',
@@ -852,14 +865,19 @@ export class SunsynkPowerFlowCard extends LitElement {
 			config.grid?.grid_off_colour || gridColour,
 		);
 
+		const generatorActiveStates = (
+			config.generator?.active_states ?? ['generator', '1']
+		).map((s) => s.toLowerCase());
+		const generatorActive = config.entities?.generator_status
+			? generatorActiveStates.includes(stateGeneratorStatus.state.toLowerCase())
+			: false;
+		const generatorColour = this.colourConvert(
+			config.generator?.colour || '#FFCD11',
+		);
+
 		let nonessentialLoads = config.grid?.additional_loads;
 		if (!validnonLoadValues.includes(nonessentialLoads)) {
 			nonessentialLoads = 0;
-		}
-
-		let pvEfficiencyMode = config.solar?.efficiency;
-		if (!validnonLoadValues.includes(pvEfficiencyMode)) {
-			pvEfficiencyMode = 0;
 		}
 
 		const gridShowDailyBuy = config.grid?.show_daily_buy;
@@ -1492,9 +1510,8 @@ export class SunsynkPowerFlowCard extends LitElement {
 				return 0; // Default case
 			};
 
-			let totalSeconds = 0;
 			if (batteryEnergy !== 0) {
-				totalSeconds = calculateTotalSeconds(
+				const totalSeconds = calculateTotalSeconds(
 					stateBatterySoc,
 					batteryShutdown,
 					batteryCapacity,
@@ -1527,9 +1544,8 @@ export class SunsynkPowerFlowCard extends LitElement {
 				batteryDuration += `${minutes} ${localize('common.min')}`;
 			}
 
-			let totalSeconds2 = 0;
 			if (battery2Energy !== 0) {
-				totalSeconds2 = calculateTotalSeconds(
+				const totalSeconds2 = calculateTotalSeconds(
 					stateBattery2Soc,
 					batteryShutdown2,
 					battery2Capacity,
@@ -2034,11 +2050,15 @@ export class SunsynkPowerFlowCard extends LitElement {
 		}
 
 		if (config && config.grid && config.grid.animation_speed) {
+			const acPower = generatorActive
+				? Math.abs(stateGeneratorPower.toPower() || 0)
+				: Math.abs(totalGridPower);
+			const acMaxPower = generatorActive
+				? config.generator?.max_power || acPower
+				: gridMaxPower.toNum() || acPower;
 			const speed =
 				config.grid.animation_speed -
-				(config.grid.animation_speed - 1) *
-					(Math.abs(totalGridPower) /
-						(gridMaxPower.toNum() || Math.abs(totalGridPower)));
+				(config.grid.animation_speed - 1) * (acPower / acMaxPower);
 			this.changeAnimationSpeed(`grid1`, speed);
 			this.changeAnimationSpeed(`grid`, speed);
 			this.changeAnimationSpeed(`grid2`, speed);
@@ -2118,18 +2138,18 @@ export class SunsynkPowerFlowCard extends LitElement {
 
 		//console.log(`${normalizedPvPercentage} % normalizedPVPercentage to load, ${normalizedBatteryPercentage} % normalizedBatteryPercentage to load`);
 
-		let pvPercentage = 0;
-		let batteryPercentage = 0;
-		let gridPercentage = 0;
-		if (totalPercentage > 100) {
-			pvPercentage = Utils.toNum(normalizedPvPercentage, 0);
-			batteryPercentage = Utils.toNum(normalizedBatteryPercentage, 0);
-		} else {
-			pvPercentage = Utils.toNum(Math.min(pvPercentageRaw, 100), 0);
-			batteryPercentage = Utils.toNum(Math.min(batteryPercentageRaw, 100), 0);
-			gridPercentage =
-				totalGridPower > 0 ? 100 - (pvPercentage + batteryPercentage) : 0;
-		}
+		const pvPercentage =
+			totalPercentage > 100
+				? Utils.toNum(normalizedPvPercentage, 0)
+				: Utils.toNum(Math.min(pvPercentageRaw, 100), 0);
+		const batteryPercentage =
+			totalPercentage > 100
+				? Utils.toNum(normalizedBatteryPercentage, 0)
+				: Utils.toNum(Math.min(batteryPercentageRaw, 100), 0);
+		const gridPercentage =
+			totalPercentage <= 100 && totalGridPower > 0
+				? 100 - (pvPercentage + batteryPercentage)
+				: 0;
 
 		//console.log(`${pvPercentage} % PVPercentage, ${batteryPercentage} % BatteryPercentage, ${gridPercentage} % GridPercentage`);
 
@@ -2172,15 +2192,14 @@ export class SunsynkPowerFlowCard extends LitElement {
 				? 0
 				: (gridPercentageRawBat / totalPercentageBat) * 100;
 
-		let pvPercentageBat = 0;
-		let gridPercentageBat = 0;
-		if (totalPercentageBat > 100) {
-			pvPercentageBat = Utils.toNum(normalizedPvPercentage_bat, 0);
-			gridPercentageBat = Utils.toNum(normalizedGridPercentage, 0);
-		} else {
-			pvPercentageBat = Utils.toNum(Math.min(pvPercentageRawBat, 100), 0);
-			gridPercentageBat = Utils.toNum(Math.min(gridPercentageRawBat, 100), 0);
-		}
+		const pvPercentageBat =
+			totalPercentageBat > 100
+				? Utils.toNum(normalizedPvPercentage_bat, 0)
+				: Utils.toNum(Math.min(pvPercentageRawBat, 100), 0);
+		const gridPercentageBat =
+			totalPercentageBat > 100
+				? Utils.toNum(normalizedGridPercentage, 0)
+				: Utils.toNum(Math.min(gridPercentageRawBat, 100), 0);
 
 		let flowBatColour: string;
 		switch (true) {
@@ -2763,6 +2782,13 @@ export class SunsynkPowerFlowCard extends LitElement {
 			customGridIconColour,
 			maximumSOC,
 			batteryCount,
+			generatorActive,
+			generatorColour,
+			stateGeneratorPower,
+			stateGeneratorVoltage,
+			stateGeneratorFrequency,
+			stateGeneratorCurrent,
+			stateDayGeneratorEnergy,
 		};
 
 		let template: TemplateResult | null = null;

--- a/src/localize/languages/ca.json
+++ b/src/localize/languages/ca.json
@@ -55,6 +55,8 @@
     "running": "Running",
     "sleepmode": "Sleep Mode",
     "grid_name": "Grid",
+    "generator_name": "Generador",
+    "daily_generator_energy": "GENERADOR DIARI",
     "limit": "Limit",
     "off": "Off",
     "lowpower": "Low Power",

--- a/src/localize/languages/cn.json
+++ b/src/localize/languages/cn.json
@@ -55,6 +55,8 @@
     "running": "运行中",
     "sleepmode": "睡眠模式",
     "grid_name": "电网",
+    "generator_name": "发电机",
+    "daily_generator_energy": "每日发电量",
     "limit": "限制",
     "off": "关闭",
     "lowpower": "低功率",

--- a/src/localize/languages/cs.json
+++ b/src/localize/languages/cs.json
@@ -55,6 +55,8 @@
     "running": "Running",
     "sleepmode": "Sleep Mode",
     "grid_name": "Grid",
+    "generator_name": "Generátor",
+    "daily_generator_energy": "DENNÍ GENERÁTOR",
     "limit": "Omezení",
     "off": "Off",
     "lowpower": "Low Power",

--- a/src/localize/languages/da.json
+++ b/src/localize/languages/da.json
@@ -55,6 +55,8 @@
     "running": "Kører",
     "sleepmode": "Sleep Mode",
     "grid_name": "Grid",
+    "generator_name": "Generator",
+    "daily_generator_energy": "DAGLIG GENERATOR",
     "limit": "Limit",
     "off": "Off",
     "lowpower": "Low Power",

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -55,6 +55,8 @@
     "running": "Running",
     "sleepmode": "Sleep Mode",
     "grid_name": "Grid",
+    "generator_name": "Generator",
+    "daily_generator_energy": "TAGESENERGIE GENERATOR",
     "limit": "Limit",
     "off": "Off",
     "lowpower": "Low Power",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -55,6 +55,8 @@
     "running": "Running",
     "sleepmode": "Sleep Mode",
     "grid_name": "Grid",
+    "generator_name": "Generator",
+    "daily_generator_energy": "DAILY GENERATOR",
     "limit": "Limit",
     "off": "Off",
     "lowpower": "Low Power",

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -55,6 +55,8 @@
     "running": "Running",
     "sleepmode": "Sleep Mode",
     "grid_name": "Grid",
+    "generator_name": "Generador",
+    "daily_generator_energy": "GENERADOR DIARIO",
     "limit": "Limit",
     "off": "Off",
     "lowpower": "Low Power",

--- a/src/localize/languages/et.json
+++ b/src/localize/languages/et.json
@@ -55,6 +55,8 @@
     "running": "Running",
     "sleepmode": "Sleep Mode",
     "grid_name": "Grid",
+    "generator_name": "Generaator",
+    "daily_generator_energy": "PÄEVANE GENERAATOR",
     "limit": "Limit",
     "off": "Off",
     "lowpower": "Low Power",

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -55,6 +55,8 @@
     "running": "Running",
     "sleepmode": "Sleep Mode",
     "grid_name": "Réseau",
+    "generator_name": "Génératrice",
+    "daily_generator_energy": "PROD. GÉNÉRATRICE",
     "limit": "Limit",
     "off": "Off",
     "lowpower": "Low Power",

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -55,6 +55,8 @@
     "running": "Running",
     "sleepmode": "Sleep Mode",
     "grid_name": "Grid",
+    "generator_name": "Generatore",
+    "daily_generator_energy": "GENERATORE GIORNALIERO",
     "limit": "Limit",
     "off": "Off",
     "lowpower": "Low Power",

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -55,6 +55,8 @@
     "running": "Running",
     "sleepmode": "Sleep Mode",
     "grid_name": "Grid",
+    "generator_name": "Generator",
+    "daily_generator_energy": "DAGELIJKSE GENERATOR",
     "limit": "Limit",
     "off": "Off",
     "lowpower": "Low Power",

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -55,6 +55,8 @@
     "running": "Uruchomiony",
     "sleepmode": "Tryb uśpienia",
     "grid_name": "Sieć",
+    "generator_name": "Generator",
+    "daily_generator_energy": "GENERATOR DZIENNY",
     "limit": "Limit",
     "off": "Wyłączone",
     "lowpower": "Niskie zużycie",

--- a/src/localize/languages/pt-br.json
+++ b/src/localize/languages/pt-br.json
@@ -55,6 +55,8 @@
     "running": "Rodando",
     "sleepmode": "Dormindo",
     "grid_name": "Rede",
+    "generator_name": "Gerador",
+    "daily_generator_energy": "GERADOR DIÁRIO",
     "limit": "Limit",
     "off": "Off",
     "lowpower": "Low Power",

--- a/src/localize/languages/ru.json
+++ b/src/localize/languages/ru.json
@@ -55,6 +55,8 @@
     "running": "Работает",
     "sleepmode": "Спящий Режим",
     "grid_name": "Сеть",
+    "generator_name": "Генератор",
+    "daily_generator_energy": "ГЕНЕРАТОР ЗА ДЕНЬ",
     "limit": "Лимит",
     "off": "Off",
     "lowpower": "Low Power",

--- a/src/localize/languages/sk.json
+++ b/src/localize/languages/sk.json
@@ -55,6 +55,8 @@
     "running": "Running",
     "sleepmode": "Sleep Mode",
     "grid_name": "Grid",
+    "generator_name": "Generátor",
+    "daily_generator_energy": "DENNÝ GENERÁTOR",
     "limit": "Limit",
     "off": "Off",
     "lowpower": "Low Power",

--- a/src/localize/languages/sl.json
+++ b/src/localize/languages/sl.json
@@ -55,6 +55,8 @@
     "running": "delovanje",
     "sleepmode": "način spanja",
     "grid_name": "omrežje",
+    "generator_name": "Generator",
+    "daily_generator_energy": "DNEVNI GENERATOR",
     "limit": "omejitev",
     "off": "izklopljeno",
     "lowpower": "nizka moč",

--- a/src/localize/languages/sv.json
+++ b/src/localize/languages/sv.json
@@ -55,6 +55,8 @@
     "running": "Igång",
     "sleepmode": "Viloläge",
     "grid_name": "Nät",
+    "generator_name": "Generator",
+    "daily_generator_energy": "DAGLIG GENERATOR",
     "limit": "Begränsning",
     "off": "Av",
     "lowpower": "Låg Effekt",

--- a/src/localize/languages/uk.json
+++ b/src/localize/languages/uk.json
@@ -55,6 +55,8 @@
     "running": "Працює",
     "sleepmode": "Режим сну",
     "grid_name": "Мережа",
+    "generator_name": "Генератор",
+    "daily_generator_energy": "ГЕНЕРАТОР ЗА ДЕНЬ",
     "limit": "Ліміт",
     "off": "Вимкнено",
     "lowpower": "Низька потужність",

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,6 +249,14 @@ export interface sunsynkPowerFlowCardConfig extends LovelaceCardConfig {
 		navigate: string;
 		invert_flow: boolean;
 	};
+	generator: {
+		colour: string;
+		name: string;
+		show_daily: boolean;
+		navigate: string;
+		active_states: string[];
+		max_power: number;
+	};
 	entities: CardConfigEntities;
 }
 
@@ -371,6 +379,12 @@ export interface CardConfigEntities {
 	prog5_charge: string;
 	prog6_charge: string;
 	max_sell_power: string;
+	generator_status: string;
+	generator_power: string;
+	generator_voltage: string;
+	generator_frequency: string;
+	generator_current: string;
+	day_generator_energy: string;
 }
 
 export interface InverterSettings {
@@ -619,4 +633,11 @@ export interface DataDto {
 	customGridIconColour;
 	maximumSOC;
 	batteryCount;
+	generatorActive: boolean;
+	generatorColour: string;
+	stateGeneratorPower: CustomEntity;
+	stateGeneratorVoltage: CustomEntity;
+	stateGeneratorFrequency: CustomEntity;
+	stateGeneratorCurrent: CustomEntity;
+	stateDayGeneratorEnergy: CustomEntity;
 }


### PR DESCRIPTION
## Summary

- Adds a new `generator` configuration section that lets users specify a backup generator as an alternative AC source
- When the generator is detected as active (via a configurable `generator_status` entity and `active_states` list), the card replaces the grid icon and all associated data with generator-specific metrics (power, voltage, frequency, current, daily energy)
- Flow animation speed is driven by `generator_power` vs `generator.max_power`, mirroring the existing grid animation logic
- The compact card additionally shows `V / Hz` above the generator icon when active
- `active_states` is flexible: works with binary sensors (`on`/`off`), text sensors (`generator`), or numeric sensors (`1`/`0`) — no helper entities needed
- All 18 language files updated with `generator_name` and `daily_generator_energy` keys
- Pre-existing `no-useless-assignment` lint errors (introduced by the ESLint v10 upgrade) fixed in `index.ts`

## Motivation

Closes #808 — on-grid systems with a backup generator currently have no way to visualise generator operation. The generator and grid are mutually exclusive AC sources, so this replaces the grid display rather than adding a new panel.

## Screenshots

| Card Style | Grid Mode | Generator Mode |
|---|---|---|
| **Full** | ![full-grid](https://github.com/user-attachments/assets/a122a428-55a1-446d-a3b4-036790402af1) | ![full-generator](https://github.com/user-attachments/assets/b4620424-c0f1-42d3-bead-75b27c671685) |
| **Compact** | ![compact-grid](https://github.com/user-attachments/assets/fa2da3c8-51a3-4fe9-bd88-17e4852a8562) | ![compact-generator](https://github.com/user-attachments/assets/6be5a6bd-60f7-416a-9d98-a608d9442e96) |

## Example Configuration

```yaml
generator:
  colour: "#FFCD11"
  name: Generator
  show_daily: true
  max_power: 8000
  active_states:
    - generator
    - "1"

entities:
  generator_status: sensor.inverter_ac_input_type
  generator_power: sensor.generator_power
  generator_voltage: sensor.generator_voltage
  generator_frequency: sensor.generator_frequency
  generator_current: sensor.generator_current
  day_generator_energy: sensor.generator_energy_today
```

## Test plan

- [x] Grid mode displays correctly with generator config present but inactive
- [x] Generator mode activates when `generator_status` matches an `active_states` value
- [x] All flow bubbles stop when generator power is 0
- [ ] Animation speed scales correctly with `generator_power` / `max_power`
- [x] Clicking generator icon opens `generator_status` entity
- [x] Clicking power value opens `generator_power` entity
- [x] Compact card shows `V / Hz` above icon in generator mode
- [x] Daily generator energy displays when `show_daily: true`
- [x] No regression for users without generator config